### PR TITLE
[backport] [object_buffer_pool] reduce mutex lock scope in WriteChunk (#43150)

### DIFF
--- a/src/ray/object_manager/object_buffer_pool.h
+++ b/src/ray/object_manager/object_buffer_pool.h
@@ -195,6 +195,8 @@ class ObjectBufferPool {
     std::vector<CreateChunkState> chunk_state;
     /// The number of chunks left to seal before the buffer is sealed.
     uint64_t num_seals_remaining;
+    /// The number of inflight copy operations.
+    uint64_t num_inflight_copies = 0;
   };
 
   /// Returned when GetChunk or CreateChunk fails.


### PR DESCRIPTION
Backport the mutex lock fix in main Ray repo. See original PR for details: https://github.com/ray-project/ray/pull/43434

whl: https://ray-ci-artifact-pr-public.s3.amazonaws.com/7692d63f2d32c4b0da4166cf759190ba7f056bee/tmp/artifacts/.whl/.whl/ray-2.9.3-cp38-cp38-manylinux2014_x86_64.whl