### PR TITLE
[Backport][data] fix a race condition issue in OpBufferQueue (#43015)

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -117,6 +117,8 @@ class OpBufferQueue:
         self._queue = deque()
         self._num_per_split = defaultdict(int)
         self._lock = threading.Lock()
+        # Used to buffer output RefBundles indexed by output splits.
+        self._outputs_by_split = defaultdict(deque)
         super().__init__()
 
     @property
@@ -171,14 +173,23 @@ class OpBufferQueue:
             except IndexError:
                 pass
         else:
-            # TODO(hchen): Index the queue by output_split_idx to
-            # avoid linear scan.
-            for i in range(len(self._queue)):
-                ref = self._queue[i]
-                if ref.output_split_idx == output_split_idx:
-                    ret = ref
-                    del self._queue[i]
-                    break
+            with self._lock:
+                split_queue = self._outputs_by_split[output_split_idx]
+            if len(split_queue) == 0:
+                # Move all ref bundles to their indexed queues
+                # Note, the reason why we do indexing here instead of in the append
+                # is because only the last `OpBufferQueue` in the DAG, which will call
+                # pop with output_split_idx, needs indexing.
+                # If we also index the `OpBufferQueue`s in the middle, we cannot
+                # preserve the order of ref bundles with different output splits.
+                with self._lock:
+                    while len(self._queue) > 0:
+                        ref = self._queue.popleft()
+                        self._outputs_by_split[ref.output_split_idx].append(ref)
+            try:
+                ret = split_queue.popleft()
+            except IndexError:
+                pass
         if ret is None:
             return None
         with self._lock:


### PR DESCRIPTION
---------
Backporting https://github.com/ray-project/ray/pull/43015 to fix:

 IndexError: deque index out of range

Build PR against OSS: https://github.com/ray-project/ray/pull/44469

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
