### PR TITLE
[Ray backport version 2.32] [ci] upgrade manylinux image (#46361)

### DIFF
--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
 ARG HOSTTYPE
-FROM quay.io/pypa/manylinux2014_${HOSTTYPE}:2023-11-13-f6b0c51
+FROM quay.io/pypa/manylinux2014_${HOSTTYPE}:2024-07-01-8dac23b
 
 ARG BUILDKITE_BAZEL_CACHE_URL
 
@@ -10,4 +10,20 @@ ENV RAY_INSTALL_JAVA=1
 ENV BUILDKITE_BAZEL_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
 
 COPY ci/build/build-manylinux-forge.sh /tmp/build-manylinux-forge.sh
-RUN /tmp/build-manylinux-forge.sh
+
+RUN <<EOF
+#!/bin/bash
+
+# Centos 7 is EOL and is no longer available from the usual mirrors, so switch
+# to https://vault.centos.org
+sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/*.repo
+sed -i 's;^.*baseurl=http://mirror;baseurl=https://vault;g' /etc/yum.repos.d/*.repo
+if [ "${HOSTTYPE}" == "aarch64" ]; then
+  sed -i 's;/centos/7/;/altarch/7/;g' /etc/yum.repos.d/*.repo
+fi
+
+./tmp/build-manylinux-forge.sh
+
+EOF
+

--- a/ci/docker/manylinux.aarch64.wanda.yaml
+++ b/ci/docker/manylinux.aarch64.wanda.yaml
@@ -1,6 +1,6 @@
 name: "manylinux-aarch64"
 froms:
-  - quay.io/pypa/manylinux2014_aarch64:2023-11-13-f6b0c51
+  - quay.io/pypa/manylinux2014_aarch64:2024-07-01-8dac23b
 srcs:
   - ci/build/build-manylinux-forge.sh
 build_args:

--- a/ci/docker/manylinux.wanda.yaml
+++ b/ci/docker/manylinux.wanda.yaml
@@ -1,6 +1,6 @@
 name: "manylinux"
 froms:
-  - quay.io/pypa/manylinux2014_x86_64:2023-11-13-f6b0c51
+  - quay.io/pypa/manylinux2014_x86_64:2024-07-01-8dac23b
 srcs:
   - ci/build/build-manylinux-forge.sh
 build_args:


### PR DESCRIPTION
This PR is necessary to get the Ray pipeline to build images for us

Upgrade manylinux image to see if it fixes the mirrolist.centoos deprecated issue

Test:
- CI

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
