### PR TITLE
[Ray backport 2.11] [dashboard] add memray to requirements.txt again (#44401)

### DIFF
--- a/dashboard/modules/reporter/profile_manager.py
+++ b/dashboard/modules/reporter/profile_manager.py
@@ -353,6 +353,9 @@ class MemoryProfilingManager:
             cmd.append("--verbose")
         cmd.append(str(pid))
 
+        if await _can_passwordless_sudo():
+            cmd = ["sudo", "-n"] + cmd
+
         process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=subprocess.PIPE,

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -60,3 +60,4 @@ pandas>=1.3
 pydantic!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,<3  # Serve users can use pydantic<2
 py-spy>=0.2.0
 watchfiles
+memray; sys_platform != "win32" # memray is not supported on Windows

--- a/python/setup.py
+++ b/python/setup.py
@@ -250,6 +250,7 @@ if setup_spec.type == SetupType.RAY:
             "prometheus_client >= 0.7.1",
             "smart_open",
             "virtualenv >=20.0.24, !=20.21.1",  # For pip runtime env.
+            "memray; sys_platform != 'win32'",
         ],
         "client": [
             # The Ray client needs a specific range of gRPC to work:


### PR DESCRIPTION
#44315 is reverted since windows tests are failing. The reason is that memray does not support windows so the pip requirements is failed to run.

This PR fixed the requirements issue by conditional install memray when current system platform is not win32

Note: In last PR, we added memray as a required dependency for dashboard (default), and it's not set required in this PR.

---------

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
