### PR TITLE
[Backport][Ray Dashboard] make memory profile href link relative path (#46564)

### DIFF
--- a/dashboard/client/src/common/ProfilingLink.tsx
+++ b/dashboard/client/src/common/ProfilingLink.tsx
@@ -312,7 +312,7 @@ export const MemoryProfilingButton = ({
   if (!pid || !ip) {
     return <div></div>;
   }
-  const profilerUrl = `/memory_profile?pid=${pid}&ip=${ip}`;
+  const profilerUrl = `memory_profile?pid=${pid}&ip=${ip}`;
 
   return <ProfilerButton profilerUrl={profilerUrl} type={type} />;
 };
@@ -325,7 +325,7 @@ export const TaskMemoryProfilingButton = ({
   if (!taskId) {
     return null;
   }
-  const profilerUrl = `/memory_profile?task_id=${taskId}&attempt_number=${attemptNumber}&node_id=${nodeId}`;
+  const profilerUrl = `memory_profile?task_id=${taskId}&attempt_number=${attemptNumber}&node_id=${nodeId}`;
 
   return <ProfilerButton profilerUrl={profilerUrl} />;
 };


### PR DESCRIPTION
When we host ray dashboard behind a prefix URL Path e.g. https://<some>.<ray>.<domain_name>/ray_dashboard/ it's important to use relative href link instead of having a forward slash / to prevent reset the URL Path , this change is to ensure consistent behavior with other similar profiling URL such as cpu profile and traceback

ideally we want https://<some>.<ray>.<domain_name>/ray_dashboard/memory_profile... instead of https://<some>.<ray>.<domain_name>/memory_profile...

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
