### PR TITLE
[Backport ray 2.36.0] Fix arrow_parquet_args

### DIFF
--- a/python/ray/data/datasource/parquet_datasink.py
+++ b/python/ray/data/datasource/parquet_datasink.py
@@ -6,6 +6,7 @@ from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.util import call_with_retry
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
+from ray.data.datasource.file_based_datasource import _resolve_kwargs
 from ray.data.datasource.block_path_provider import BlockWritePathProvider
 from ray.data.datasource.file_datasink import _FileDatasink
 from ray.data.datasource.filename_provider import FilenameProvider
@@ -68,11 +69,14 @@ class _ParquetDatasink(_FileDatasink):
             blocks[0], ctx.task_idx, 0
         )
         write_path = posixpath.join(self.path, filename)
+        write_kwargs = _resolve_kwargs(
+            self.arrow_parquet_args_fn, **self.arrow_parquet_args
+        )
 
         def write_blocks_to_path():
             with self.open_output_stream(write_path) as file:
                 schema = BlockAccessor.for_block(blocks[0]).to_arrow().schema
-                with pq.ParquetWriter(file, schema) as writer:
+                with pq.ParquetWriter(file, schema, **write_kwargs) as writer:
                     for block in blocks:
                         table = BlockAccessor.for_block(block).to_arrow()
                         writer.write_table(table)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Copy change from OSS fix. https://github.com/ray-project/ray/pull/47161

This allows us to correctly pass in `arrow_parquet_args` when calling `ray.data.write_parquet`. Most notably, this means we can write ZSTD compressed parquet files.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
