### PR TITLE
[Ray Data Optimization] Add environment variable overrides for max_safe_block_size…

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -34,7 +34,7 @@ DEFAULT_SHUFFLE_TARGET_MAX_BLOCK_SIZE = 1024 * 1024 * 1024
 # We will attempt to slice blocks whose size exceeds this factor *
 # target_max_block_size. We will warn the user if slicing fails and we produce
 # blocks larger than this threshold.
-MAX_SAFE_BLOCK_SIZE_FACTOR = 1.5
+MAX_SAFE_BLOCK_SIZE_FACTOR = float(os.environ.get("RAY_DATA_MAX_SAFE_BLOCK_SIZE_FACTOR", "1.5"))
 
 DEFAULT_TARGET_MIN_BLOCK_SIZE = 1 * 1024 * 1024
 


### PR DESCRIPTION

We can increase this max_safe_block_size_factor to avoid block slicing in output_buffer.py

Test run:
https://tcp.pinadmin.com/project/homefeed/ray/ekgv9nck
