### PR TITLE
[PT 2.6 perf fix] Remove expensive memory_full_info kernel call

### DIFF
--- a/dashboard/modules/reporter/reporter_agent.py
+++ b/dashboard/modules/reporter/reporter_agent.py
@@ -610,7 +610,7 @@ class ReporterAgent(
                             "cpu_times",
                             "cmdline",
                             "memory_info",
-                            "memory_full_info",
+                            # "memory_full_info", # remove it as an action item for pytorch 2.6 perf debug
                             "num_fds",
                         ]
                     )
@@ -648,7 +648,7 @@ class ReporterAgent(
                     "cpu_times",
                     "cmdline",
                     "memory_info",
-                    "memory_full_info",
+                    # "memory_full_info", # remove it as an action item for pytorch 2.6 perf debug
                     "num_fds",
                 ]
             )
@@ -665,7 +665,7 @@ class ReporterAgent(
                 "cpu_times",
                 "cmdline",
                 "memory_info",
-                "memory_full_info",
+                # "memory_full_info", # remove it as an action item for pytorch 2.6 perf debug
                 "num_fds",
             ]
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

[PyTorch 2.6 perf fix]
The ray monitoring process [agent.py](https://github.com/pinterest/ray/blob/60d08af0eaf42610a0b76abdd8e37d5e43d9cb32/dashboard/agent.py) runs periodic memory stats collection which used an expensive [low-level kernel](https://psutil.readthedocs.io/en/latest/#psutil.Process.memory_full_info) call (ray [callsite](https://github.com/pinterest/ray/blob/60d08af0eaf42610a0b76abdd8e37d5e43d9cb32/dashboard/modules/reporter/reporter_agent.py#L613)) caused the training process to stall. Removing the expensive kernel call fixed the regression on PyTorch 2.6.

## Related issue number
The call was noticed to be expensive in 2019
[Reduce reporter CPU by ericl · Pull Request #6553 · ray-project/ray](https://github.com/ray-project/ray/pull/6553)

then un-noticed in 2022
[[Core] Export additional metrics for workers and Raylet memory by mwtian · Pull Request #25418 · ray-project/ray](https://github.com/ray-project/ray/pull/25418)

As a next step, we would like to contribute to Ray OSS by exposing allowed metrics as a config. 

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
