### PR TITLE
[data/air] handle numpy > 2.0.0 behaviour in _create_possibly_ragged_ndarray

### DIFF
--- a/python/ray/air/util/tensor_extensions/utils.py
+++ b/python/ray/air/util/tensor_extensions/utils.py
@@ -46,8 +46,16 @@ def _create_possibly_ragged_ndarray(
             # `np.array(...)` without the `dtype=object` parameter will raise a
             # VisibleDeprecationWarning which we suppress.
             # More details: https://stackoverflow.com/q/63097829
-            warnings.simplefilter("ignore", category=np.VisibleDeprecationWarning)
-            return np.array(values, copy=False)
+            if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+                copy_if_needed = None
+                warning_type = np.exceptions.VisibleDeprecationWarning
+            else:
+                copy_if_needed = False
+                warning_type = np.VisibleDeprecationWarning
+
+            warnings.simplefilter("ignore", category=warning_type)
+            arr = np.array(values, copy=copy_if_needed)
+            return arr
     except ValueError as e:
         # Constructing a ragged ndarray directly via `np.array(...)`
         # without the `dtype=object` parameter will raise a ValueError.


### PR DESCRIPTION
## Summary

Cherry-picking the commit from this PR: [handle numpy > 2.0.0 behaviour in _create_possibly_ragged_ndarray](https://github.com/ray-project/ray/pull/48064) which fixes the following error: 

```AttributeError: module 'numpy' has no attribute 'VisibleDeprecationWarning'```

## Test Plan

Built wheels locally and tested

```shell
docker run -ti --rm \
    -e BUILDKITE_COMMIT="$(git rev-parse HEAD)" \
    -e BUILD_ONE_PYTHON_ONLY=py311 \
    -w /ray -v `pwd`:/ray \
    quay.io/pypa/manylinux2014_x86_64 \
    /ray/python/build-wheel-manylinux2014.sh
```