### PR TITLE
[Backport 2.53.0] Eager Data Resource Cleanup on Train Run Failures and Aborts

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -46,8 +46,9 @@ class StreamSplitDataIterator(DataIterator):
         See also: `Dataset.streaming_split`.
         """
         # To avoid deadlock, the concurrency on this actor must be set to at least `n`.
+        # We add 1 to the concurrency to allow for a shutdown_executor thread to run.
         coord_actor = SplitCoordinator.options(
-            max_concurrency=n,
+            max_concurrency=n + 1,
             scheduling_strategy=NodeAffinitySchedulingStrategy(
                 ray.get_runtime_context().get_node_id(), soft=False
             ),
@@ -245,6 +246,13 @@ class SplitCoordinator:
         finally:
             # Track overhead time in the instance variable
             self._coordinator_overhead_s += time.perf_counter() - start_time
+
+    def shutdown_executor(self):
+        """Shuts down the internal data executor."""
+        with self._lock:
+            # Call shutdown on the executor
+            if self._executor is not None:
+                self._executor.shutdown(force=False)
 
     def _barrier(self, split_idx: int) -> int:
         """Arrive and block until the start of the given epoch."""

--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -198,6 +198,22 @@ py_test(
 )
 
 py_test(
+    name = "test_data_resource_cleanup",
+    size = "medium",
+    srcs = ["tests/test_data_resource_cleanup.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_env_callbacks",
     size = "small",
     srcs = ["tests/test_env_callbacks.py"],

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -1,19 +1,31 @@
 import copy
+import logging
 from typing import Dict, List
 
+import ray
 import ray.train
+from ray.actor import ActorHandle
 from ray.data import DataIterator
+from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
 from ray.data.context import DataContext
+from ray.exceptions import GetTimeoutError
 from ray.train.v2._internal.data_integration.interfaces import (
     DatasetShardMetadata,
     DatasetShardProvider,
 )
-from ray.train.v2._internal.execution.callback import WorkerGroupCallback
+from ray.train.v2._internal.execution.callback import (
+    ControllerCallback,
+    WorkerGroupCallback,
+)
 from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.worker_group.worker_group import (
     Worker,
     WorkerGroup,
+    WorkerGroupContext,
 )
+from ray.types import ObjectRef
+
+logger = logging.getLogger(__name__)
 
 
 class RayDatasetShardProvider:
@@ -34,13 +46,15 @@ class RayDatasetShardProvider:
         return self._dataset_iterators[dataset_info.dataset_name]
 
 
-class DatasetsSetupCallback(WorkerGroupCallback):
-    """The callback to setup Ray Datasets for the worker group."""
+class DatasetsSetupCallback(WorkerGroupCallback, ControllerCallback):
+    """A callback for managing Ray Datasets for the worker group."""
 
     def __init__(self, train_run_context: TrainRunContext):
         self._datasets = train_run_context.datasets
         self._data_config = copy.deepcopy(train_run_context.dataset_config)
         self._scaling_config = train_run_context.scaling_config
+        self._coordinator_actors: List[ActorHandle] = []
+        self._shutdown_refs: List[ObjectRef] = []
 
         # Capture the current DataContext to propagate it to
         # the Train workers later.
@@ -58,6 +72,31 @@ class DatasetsSetupCallback(WorkerGroupCallback):
         """Return the resources reserved for training, so that Data can exclude
         these resources logically from its available pool."""
         return scaling_config.total_resources
+
+    def _get_coordinator_actors(
+        self, ds_iterators_per_rank: List[Dict[str, DataIterator]]
+    ) -> List[ActorHandle]:
+        """
+        Returns a list of each unique SplitCoordinator actor handle given the iterators per rank.
+        These handles will later be used to call shutdown on the actors.
+        """
+
+        # Note: Currently, we only need to check rank 0 for split iterators.
+        # In the future, if datasets can be split across only a subset of ranks,
+        # we may need to process all ranks.
+        rank_0_iterators = ds_iterators_per_rank[0]
+        coord_actors = [
+            iterator._coord_actor
+            for iterator in rank_0_iterators.values()
+            if isinstance(iterator, StreamSplitDataIterator)
+        ]
+        return coord_actors
+
+    def _shutdown_data_executors(self):
+        """Eagerly shutdown the data executors of the split coordinator actors."""
+        self._shutdown_refs = [
+            coord.shutdown_executor.remote() for coord in self._coordinator_actors
+        ]
 
     # --------------------------
     # WorkerGroupCallback
@@ -84,6 +123,8 @@ class DatasetsSetupCallback(WorkerGroupCallback):
         )
         assert len(ds_iterators_per_rank) == world_size
 
+        self._coordinator_actors = self._get_coordinator_actors(ds_iterators_per_rank)
+
         shard_providers_per_rank = [
             RayDatasetShardProvider(ds_iterators=ds_iterators_per_rank[rank])
             for rank in range(world_size)
@@ -99,3 +140,25 @@ class DatasetsSetupCallback(WorkerGroupCallback):
             _propagate_data_context,
             self._data_context,
         )
+
+    def after_worker_group_shutdown(
+        self, worker_group_context: WorkerGroupContext
+    ) -> None:
+        self._shutdown_data_executors()
+
+    def after_worker_group_abort(
+        self, worker_group_context: WorkerGroupContext
+    ) -> None:
+        self._shutdown_data_executors()
+
+    # --------------------------
+    # ControllerCallback
+    # --------------------------
+
+    def before_controller_shutdown(self):
+        try:
+            ray.get(self._shutdown_refs, timeout=5)
+        except GetTimeoutError:
+            logger.error("Ray Data executor shutdown task timed out after 5 seconds.")
+        except Exception:
+            logger.exception("Failed to gracefully terminate Ray Data executors.")

--- a/python/ray/train/v2/_internal/execution/callback.py
+++ b/python/ray/train/v2/_internal/execution/callback.py
@@ -62,6 +62,10 @@ class WorkerGroupCallback(RayTrainCallback):
         should catch and handle exceptions if attempting to execute tasks."""
         pass
 
+    def after_worker_group_shutdown(self, worker_group_context: "WorkerGroupContext"):
+        """Called after the worker group is shut down."""
+        pass
+
     def after_worker_group_poll_status(
         self, worker_group_status: "WorkerGroupPollStatus"
     ):
@@ -69,6 +73,10 @@ class WorkerGroupCallback(RayTrainCallback):
 
     def before_worker_group_abort(self, worker_group_context: "WorkerGroupContext"):
         """Called before the worker group is aborted."""
+        pass
+
+    def after_worker_group_abort(self, worker_group_context: "WorkerGroupContext"):
+        """Called after the worker group is aborted."""
         pass
 
 

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -466,6 +466,9 @@ class WorkerGroup(BaseWorkerGroup):
 
             logger.debug("Worker group shutdown successful.")
 
+            for callback in self._callbacks:
+                callback.after_worker_group_shutdown(self._worker_group_context)
+
     def _clear_state(self):
         self._worker_group_state = None
         self._world_rank_to_ongoing_poll = {}
@@ -480,6 +483,9 @@ class WorkerGroup(BaseWorkerGroup):
 
         self._worker_group_state.shutdown()
         self._clear_state()
+
+        for callback in self._callbacks:
+            callback.after_worker_group_abort(self._worker_group_context)
 
     #####################################################################################
     # Polling Worker Group

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -200,7 +200,7 @@ class DataParallelTrainer:
             self.backend_config, self.scaling_config
         )
         backend_setup_callback = BackendSetupCallback(self.backend_config)
-        datasets_setup_callback = DatasetsSetupCallback(
+        datasets_callback = DatasetsSetupCallback(
             train_run_context=self.train_run_context
         )
         tpu_reservation_setup_callback = TPUReservationCallback()
@@ -209,7 +209,7 @@ class DataParallelTrainer:
                 accelerator_setup_callback,
                 tpu_reservation_setup_callback,
                 backend_setup_callback,
-                datasets_setup_callback,
+                datasets_callback,
             ]
         )
         if env_bool(RAY_CHDIR_TO_TRIAL_DIR, True):

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -82,7 +82,7 @@ def test_data_config_validation():
         ray.train.DataConfig(datasets_to_split={})
 
 
-def test_dataset_setup_callback(ray_start_4_cpus):
+def test_datasets_callback(ray_start_4_cpus):
     """Check that the `DatasetsSetupCallback` correctly configures the
     dataset shards and execution options."""
     NUM_WORKERS = 2

--- a/python/ray/train/v2/tests/test_data_resource_cleanup.py
+++ b/python/ray/train/v2/tests/test_data_resource_cleanup.py
@@ -1,0 +1,145 @@
+import sys
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+import ray
+from ray.data._internal.execution.autoscaling_requester import (
+    get_or_create_autoscaling_requester_actor,
+)
+from ray.data._internal.iterator.stream_split_iterator import (
+    SplitCoordinator,
+    _DatasetWrapper,
+)
+from ray.train.v2._internal.callbacks.datasets import DatasetsSetupCallback
+from ray.train.v2._internal.execution.worker_group import (
+    WorkerGroup,
+    WorkerGroupContext,
+)
+from ray.train.v2.tests.util import DummyObjectRefWrapper, create_dummy_run_context
+
+pytestmark = pytest.mark.usefixtures("mock_runtime_context")
+
+
+@pytest.fixture
+def ray_start_4_cpus():
+    ray.init(num_cpus=4)
+    yield
+    ray.shutdown()
+
+
+def test_datasets_callback_multiple_datasets(ray_start_4_cpus):
+    """Test that the DatasetsSetupCallback properly collects the coordinator actors for multiple datasets"""
+    # Start worker group
+    worker_group_context = WorkerGroupContext(
+        run_attempt_id="test",
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        num_workers=4,
+        resources_per_worker={"CPU": 1},
+    )
+    wg = WorkerGroup.create(
+        train_run_context=create_dummy_run_context(),
+        worker_group_context=worker_group_context,
+    )
+
+    # Create train run context
+    NUM_ROWS = 100
+
+    datasets = {
+        "sharded_1": ray.data.range(NUM_ROWS),
+        "sharded_2": ray.data.range(NUM_ROWS),
+        "unsharded": ray.data.range(NUM_ROWS),
+    }
+    dataset_config = ray.train.DataConfig(datasets_to_split=["sharded_1", "sharded_2"])
+    train_run_context = create_dummy_run_context(
+        datasets=datasets, dataset_config=dataset_config
+    )
+
+    callback = DatasetsSetupCallback(train_run_context)
+    callback.before_init_train_context(wg.get_workers())
+
+    # Two coordinator actors, one for each sharded dataset
+    coordinator_actors = callback._coordinator_actors
+    assert len(coordinator_actors) == 2
+
+
+def test_after_worker_group_abort():
+    callback = DatasetsSetupCallback(create_dummy_run_context())
+
+    # Mock SplitCoordinator shutdown_executor method
+    coord_mock = create_autospec(SplitCoordinator)
+    remote_mock = MagicMock()
+    coord_mock.shutdown_executor.remote = remote_mock
+    callback._coordinator_actors = [coord_mock]
+
+    dummy_wg_context = WorkerGroupContext(
+        run_attempt_id="test",
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        num_workers=4,
+        resources_per_worker={"CPU": 1},
+    )
+    callback.after_worker_group_abort(dummy_wg_context)
+
+    # shutdown_executor called on SplitCoordinator
+    remote_mock.assert_called_once()
+
+
+def test_after_worker_group_shutdown():
+    callback = DatasetsSetupCallback(create_dummy_run_context())
+
+    # Mock SplitCoordinator shutdown_executor method
+    coord_mock = create_autospec(SplitCoordinator)
+    remote_mock = MagicMock()
+    coord_mock.shutdown_executor.remote = remote_mock
+    callback._coordinator_actors = [coord_mock]
+
+    dummy_wg_context = WorkerGroupContext(
+        run_attempt_id="test",
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        num_workers=4,
+        resources_per_worker={"CPU": 1},
+    )
+    callback.after_worker_group_shutdown(dummy_wg_context)
+
+    # shutdown_executor called on SplitCoordinator
+    remote_mock.assert_called_once()
+
+
+def test_split_coordinator_shutdown_executor(ray_start_4_cpus):
+    """Tests that the SplitCoordinator properly requests resources for the data executor and cleans up after it is shutdown"""
+    # Start coordinator and executor
+    NUM_SPLITS = 1
+    dataset = ray.data.range(100)
+    coord = SplitCoordinator.options(name="test_split_coordinator").remote(
+        _DatasetWrapper(dataset), NUM_SPLITS, None
+    )
+    ray.get(coord.start_epoch.remote(0))
+
+    requester = get_or_create_autoscaling_requester_actor()
+    requests = ray.get(
+        requester.__ray_call__.remote(lambda requester: requester._resource_requests)
+    )
+
+    # One request made, with non-empty resource bundle
+    assert len(requests) == 1
+    resource_bundles = list(requests.values())[0][0]
+    assert isinstance(resource_bundles, list)
+    bundle = resource_bundles[0]
+    assert bundle != {}
+
+    # Shutdown data executor
+    ray.get(coord.shutdown_executor.remote())
+
+    requests = ray.get(
+        requester.__ray_call__.remote(lambda requester: requester._resource_requests)
+    )
+
+    # Old resourece request overwritten by new cleanup request
+    assert len(requests) == 1
+    resource_bundles = list(requests.values())[0][0]
+    assert isinstance(resource_bundles, dict)
+    assert resource_bundles == {}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_worker_group.py
+++ b/python/ray/train/v2/tests/test_worker_group.py
@@ -481,6 +481,9 @@ def test_worker_group_callback():
         def before_worker_group_shutdown(self, worker_group):
             self.shutdown_hook_called = True
 
+        def after_worker_group_shutdown(self, worker_group_context):
+            self.after_worker_group_shutdown_hook_called = True
+
         def after_worker_group_poll_status(self, worker_group_status):
             assert len(worker_group_status.worker_statuses) == 4
             self.poll_status_hook_called = True
@@ -495,6 +498,7 @@ def test_worker_group_callback():
     assert hooks.poll_status_hook_called
     wg.shutdown()
     assert hooks.shutdown_hook_called
+    assert hooks.after_worker_group_shutdown_hook_called
 
 
 def test_worker_log_file_paths():
@@ -519,6 +523,9 @@ def test_worker_group_abort(monkeypatch):
         def before_worker_group_abort(self, worker_group_context):
             self.abort_hook_called = True
 
+        def after_worker_group_abort(self, worker_group_context):
+            self.after_worker_group_abort_hook_called = True
+
     hooks = AssertCallback()
     wg = _default_inactive_worker_group(callbacks=[hooks])
 
@@ -540,6 +547,7 @@ def test_worker_group_abort(monkeypatch):
         shutdown_call_count == 1
     ), f"Expected shutdown to be called once, but was called {shutdown_call_count} times"
     assert hooks.abort_hook_called
+    assert hooks.after_worker_group_abort_hook_called
 
     # Bypass _assert_active method, allowing for shutdown
     monkeypatch.setattr(wg, "_assert_active", lambda: None)


### PR DESCRIPTION
backport

this will allow us to shutdown the executor and release resource, especially during training in mid epoch where we met multiple pain point in our code base because we could not do so.

---------
Following a worker failure or a user abort during a Train job, the execution of sharded datasets (provided through get_dataset_shard) is ungracefully shutdown. Consequently, any ongoing resource request made by a sharded dataset's SplitCoordinator to the AutoscalingRequester is not cancelled. This can result in resources being held for a preset timeout, leading to inefficient cluster utilization and slower train job turnarounds.

- Implements an eager shutdown path to cleanup resource requests made to the AutoscalingRequester (depicted below)
- Adds new WorkerGroupCallback hooks(`after_worker_group_abort` and `after_worker_group_shutdown`) to DatasetsSetupCallback for the new shutdown path
- Implements tests for the new cleanup path

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
