### PR TITLE
[Backport][Core] Fix psutil internal API usage in dashboard disk usage reporting (#59659)

### DIFF
--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -872,9 +872,8 @@ class ReporterAgent(
     def _get_disk_usage():
         if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
             # If in a K8s pod, disable disk display by passing in dummy values.
-            return {
-                "/": psutil._common.sdiskusage(total=1, used=0, free=1, percent=0.0)
-            }
+            sdiskusage = type(psutil.disk_usage("/"))
+            return {"/": sdiskusage(total=1, used=0, free=1, percent=0.0)}
         if sys.platform == "win32":
             root = psutil.disk_partitions()[0].mountpoint
         else:


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
<img width="1598" height="502" alt="Screenshot 2026-02-12 at 11 35 52 PM" src="https://github.com/user-attachments/assets/864d5a69-f062-4298-a0ee-87d6c25bc621" />

We see dashboard reporter_agent throwing this error that indicated psutil is missing certain attribute. Which is going to be fixed by the commit backported.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
