### PR TITLE
[Data] add option to force shutdown executor

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -247,12 +247,17 @@ class SplitCoordinator:
             # Track overhead time in the instance variable
             self._coordinator_overhead_s += time.perf_counter() - start_time
 
-    def shutdown_executor(self):
+    def shutdown_executor(self, force: bool = False):
         """Shuts down the internal data executor."""
         with self._lock:
             # Call shutdown on the executor
             if self._executor is not None:
-                self._executor.shutdown(force=False)
+                if force:
+                    self._executor.shutdown(force=True)
+                    self._executor = None
+                    self._output_iterator = None
+                else: 
+                    self._executor.shutdown(force=False)
 
     def _barrier(self, split_idx: int) -> int:
         """Arrive and block until the start of the given epoch."""


### PR DESCRIPTION
## Description
For some reason the shutdown_executor function does not guarantee clean up of all the worker that is occupying resources. And this leaking worker has also some how cause >30% throughput degradation.

This PR introduce an option to force shutdown the executor and clean up all other attribute in the SplitCoordinator that could hold reference to StreamingExecutor and it worker. After force shutdown the resource is successfully released and the throughput is back to normal.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
