### PR TITLE
[backport 42af804] Multiple gRPC connections to improve object transfer throughput (#61121)

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1022,3 +1022,7 @@ RAY_CONFIG(bool, start_python_gc_manager_thread, true)
 // Whether to enable the feature of outputting error log if the task is
 // still retryable.
 RAY_CONFIG(bool, enable_output_error_log_if_still_retry, true)
+
+// Whether to enable/disable multiple gRPC connections to improve object transfer
+// throughput.
+RAY_CONFIG(bool, experimental_object_manager_enable_multiple_connections, true)


### PR DESCRIPTION
[backporting https://github.com/ray-project/ray/commit/42af804f103666c8f96666f4cf248e9e2965c8a8]
Adds a ray configuration
`experimental_object_manager_enable_multiple_connections ` to enable creation of multiple gRPC connections using the
`GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL` config. This increases object transfer throughput.

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
